### PR TITLE
Typo in variable name 

### DIFF
--- a/deployCreateBearer/task.prod.json
+++ b/deployCreateBearer/task.prod.json
@@ -89,7 +89,7 @@
     ],
     "OutputVariables": [
         {
-            "name": "BearerToken",
+            "name": "Extension.BearerToken",
             "description": "This is the Databricks Bearer Token which you can use in further API Calls"
         }
     ],


### PR DESCRIPTION
#8 
Variable name requires Extension prefix. This is missing in the production config.