### PR TITLE
#16 Correct Output variables on Create Cluster

### DIFF
--- a/deployClusterTask/task.prod.json
+++ b/deployClusterTask/task.prod.json
@@ -128,6 +128,10 @@
         {
             "name": "Extension.DatabricksClusterId",
             "description": "This is the ClusterId created/edited for use in other requests"
+        },
+        {
+            "name": "DatabricksClusterId",
+            "description": "This is the ClusterId created/edited for use in other requests"
         }
     ],
     "execution": {

--- a/deployClusterTask/task.prod.json
+++ b/deployClusterTask/task.prod.json
@@ -127,11 +127,11 @@
     "OutputVariables": [
         {
             "name": "Extension.DatabricksClusterId",
-            "description": "This is the ClusterId created/edited for use in other requests"
+            "description": "Backwards compatibility only - please do not use"
         },
         {
             "name": "DatabricksClusterId",
-            "description": "This is the ClusterId created/edited for use in other requests"
+            "description": "This is the ClusterId created/edited for use in other requests reference as $(ClusterId) or $env:ClusterId in PS Scripts"
         }
     ],
     "execution": {

--- a/deployClusterTask/task.test.json
+++ b/deployClusterTask/task.test.json
@@ -128,6 +128,10 @@
         {
             "name": "Extension.DatabricksClusterId",
             "description": "This is the ClusterId created/edited for use in other requests"
+        },
+        {
+            "name": "DatabricksClusterId",
+            "description": "This is the ClusterId created/edited for use in other requests"
         }
     ],
     "execution": {

--- a/deployClusterTask/task.test.json
+++ b/deployClusterTask/task.test.json
@@ -127,11 +127,11 @@
     "OutputVariables": [
         {
             "name": "Extension.DatabricksClusterId",
-            "description": "This is the ClusterId created/edited for use in other requests"
+            "description": "Backwards compatibility only - please do not use"
         },
         {
             "name": "DatabricksClusterId",
-            "description": "This is the ClusterId created/edited for use in other requests"
+            "description": "This is the ClusterId created/edited for use in other requests reference as $(ClusterId) or $env:ClusterId in PS Scripts"
         }
     ],
     "execution": {

--- a/deployClusterTask/vstsDeployCluster.ps1
+++ b/deployClusterTask/vstsDeployCluster.ps1
@@ -94,7 +94,8 @@ try {
         Write-Output "Created Cluster $ClusterId"
     }
 
-    Write-Host "##vso[task.setVariable variable=DatabricksClusterId]$ClusterId"
+    Write-Host "##vso[task.setVariable variable=DatabricksClusterId;]$ClusterId"
+    Write-Host "##vso[task.setVariable variable=Extension.DatabricksClusterId;]$ClusterId"
     
     
 } finally {

--- a/deployClusterTask/vstsDeployCluster.ps1
+++ b/deployClusterTask/vstsDeployCluster.ps1
@@ -96,6 +96,7 @@ try {
 
     Write-Host "##vso[task.setVariable variable=DatabricksClusterId;]$ClusterId"
     Write-Host "##vso[task.setVariable variable=Extension.DatabricksClusterId;]$ClusterId"
+
     
     
 } finally {


### PR DESCRIPTION
Closes #16 
Relates to #14 

Now outputting old and new name. Previous issue in 14 was a non-issue and should not have been changed (caused a breaking change).