### PR TITLE
Consistent ClusterID response

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Use the option in the Databricks UI to link your notebook to a git repo or you c
 These tools are based on the PowerShell module [azure.databricks.cicd.tools](https://github.com/DataThirstLtd/azure.databricks.cicd.tools) available through PSGallery. The module has much more functionality if you require it for Libraries, Jobs and more Cluster management.
 
 # History
+- 08 Apr 2020 0.9   Corrected issue with ClusterId not always returning
 - 26 Oct 2019 0.8   Added support for Clusters
 - 18 Oct 2019 0.6   Added support for Service Principal Authentication
 - 18 Oct 2019 0.6   Added support for cleaning workspace folder before deploying

--- a/deployClusterTask/task.prod.json
+++ b/deployClusterTask/task.prod.json
@@ -131,7 +131,7 @@
         },
         {
             "name": "DatabricksClusterId",
-            "description": "This is the ClusterId created/edited for use in other requests reference as $(ClusterId) or $env:ClusterId in PS Scripts"
+            "description": "This is the ClusterId created/edited for use in other requests reference as $(DatabricksClusterId) or $env:DatabricksClusterId in PS Scripts"
         }
     ],
     "execution": {

--- a/deployClusterTask/vstsDeployCluster.ps1
+++ b/deployClusterTask/vstsDeployCluster.ps1
@@ -81,7 +81,7 @@ try {
         if ($res.Count -gt 0){
             Write-Output "Cluster $ClusterId found - editing"
             $Request['cluster_id'] = $ClusterId
-            $ClusterId = (Invoke-DatabricksAPI -API "api/2.0/clusters/edit" -Method POST -Body $Request).cluster_id
+            Invoke-DatabricksAPI -API "api/2.0/clusters/edit" -Method POST -Body $Request
         }
         else
         {

--- a/deployClusterTask/vstsDeployCluster.ps1
+++ b/deployClusterTask/vstsDeployCluster.ps1
@@ -81,7 +81,7 @@ try {
         if ($res.Count -gt 0){
             Write-Output "Cluster $ClusterId found - editing"
             $Request['cluster_id'] = $ClusterId
-            $ClusterId = Invoke-DatabricksAPI -API "api/2.0/clusters/edit" -Method POST -Body $Request
+            $ClusterId = (Invoke-DatabricksAPI -API "api/2.0/clusters/edit" -Method POST -Body $Request).cluster_id
         }
         else
         {
@@ -90,7 +90,7 @@ try {
     }
     else{
         Write-Output "Cluster $ClusterName not found - creating"
-        $ClusterId = Invoke-DatabricksAPI -API "api/2.0/clusters/create" -Method POST -Body $Request
+        $ClusterId = (Invoke-DatabricksAPI -API "api/2.0/clusters/create" -Method POST -Body $Request).cluster_id
         Write-Output "Created Cluster $ClusterId"
     }
 


### PR DESCRIPTION
Resolve #18 
The Databricks create/edit api's respond differently. Aligned the response to always return the cluster id in plain text.
Also correct the variable name in the description.